### PR TITLE
Make java_export capable of writing exclusions to the POM file it generates.

### DIFF
--- a/private/rules/has_maven_deps.bzl
+++ b/private/rules/has_maven_deps.bzl
@@ -123,7 +123,6 @@ def _has_maven_deps_impl(target, ctx):
             return _EMPTY_INFO
 
     coordinates = read_coordinates(ctx.rule.attr.tags)
-    label_to_javainfo = {target.label: target[JavaInfo]}
 
     gathered = _gathered(
         all_infos = [],

--- a/specs.bzl
+++ b/specs.bzl
@@ -210,6 +210,12 @@ def _exclusion_spec_to_json(exclusion_spec):
     """
     return "{ \"group\": \"" + exclusion_spec["group"] + "\", \"artifact\": \"" + exclusion_spec["artifact"] + "\" }"
 
+def _exclusion_spec_list_to_json(exclusion_spec):
+    """
+    Given a list of artifact exclusion spec, returns its json serialization.
+    """
+    return "[" + ", ".join([_exclusion_spec_to_json(spec) for spec in exclusion_spec]) + "]"
+
 def _override_license_types_spec_to_json(override_license_types_spec):
     """
     Given an override license types spec, returns the json serialization of the object.
@@ -246,6 +252,7 @@ json = struct(
     write_repository_credentials_spec = _repository_credentials_spec_to_json,
     write_repository_spec = _repository_spec_to_json,
     write_exclusion_spec = _exclusion_spec_to_json,
+    write_exclusion_spec_list = _exclusion_spec_list_to_json,
     write_override_license_types_spec = _override_license_types_spec_to_json,
     write_artifact_spec = _artifact_spec_to_json,
 )

--- a/tests/unit/specs_test.bzl
+++ b/tests/unit/specs_test.bzl
@@ -187,8 +187,16 @@ def _exclusion_spec_list_to_json_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(
         env,
-        "[{ \"group\": \"org.eclipse.aether\", \"artifact\": \"aether-api\" }, { \"group\": \"org.eclipse.aether\", \"artifact\": \"aether-util\" }]",
-        json.write_exclusion_spec_list([{"group": "org.eclipse.aether", "artifact": "aether-api"}, {"group": "org.eclipse.aether", "artifact": "aether-util"}]),
+        "[" +
+        "{ \"group\": \"org.eclipse.aether\", \"artifact\": \"aether-api\" }, " +
+        "{ \"group\": \"org.eclipse.aether\", \"artifact\": \"aether-util\" }" +
+        "]",
+        json.write_exclusion_spec_list(
+            [
+                {"group": "org.eclipse.aether", "artifact": "aether-api"},
+                {"group": "org.eclipse.aether", "artifact": "aether-util"},
+            ],
+        ),
     )
     return unittest.end(env)
 

--- a/tests/unit/specs_test.bzl
+++ b/tests/unit/specs_test.bzl
@@ -183,6 +183,17 @@ def _exclusion_spec_to_json_test_impl(ctx):
 
 exclusion_spec_to_json_test = unittest.make(_exclusion_spec_to_json_test_impl)
 
+def _exclusion_spec_list_to_json_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "[{ \"group\": \"org.eclipse.aether\", \"artifact\": \"aether-api\" }, { \"group\": \"org.eclipse.aether\", \"artifact\": \"aether-util\" }]",
+        json.write_exclusion_spec_list([{"group": "org.eclipse.aether", "artifact": "aether-api"}, {"group": "org.eclipse.aether", "artifact": "aether-util"}]),
+    )
+    return unittest.end(env)
+
+exclusion_spec_list_to_json_test = unittest.make(_exclusion_spec_list_to_json_test_impl)
+
 def _override_license_types_to_json_test_impl(ctx):
     env = unittest.begin(ctx)
     asserts.equals(
@@ -383,6 +394,7 @@ def artifact_specs_test_suite():
         repository_credentials_spec_to_json_test,
         repository_spec_to_json_test,
         exclusion_spec_to_json_test,
+        exclusion_spec_list_to_json_test,
         override_license_types_spec_to_json_test,
         artifact_spec_to_json_test,
     )


### PR DESCRIPTION
Makes `java_export` capable of writing exclusions to the POM file it generates.

Reused the representation of exclusions used for artifacts in `maven_intall`.

No unit tests were present for POM file generation and this PR does not add them. It only adds a unit test around the encoding of exclusions lists.